### PR TITLE
Fix incorrect call to `Doctrine\Common\Persistence\ObjectRepository`

### DIFF
--- a/ORM/PaginatedRepositoryInterface.php
+++ b/ORM/PaginatedRepositoryInterface.php
@@ -2,7 +2,7 @@
 
 namespace Jhg\DoctrinePagination\ORM;
 
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectRepository;
 use Doctrine\ORM\AbstractQuery;
 use Jhg\DoctrinePagination\Collection\PaginatedArrayCollection;
 


### PR DESCRIPTION
### Description
`\Doctrine\Common\Persistence\ObjectRepository` does not exist in `v2.7.3` of https://github.com/doctrine/orm. This PR updates the `use` statement to the correct path `\Doctrine\Persistence\ObjectRepository`